### PR TITLE
Use esModuleInterop and fix corresponding issues

### DIFF
--- a/lib/models/Sequelize.d.ts
+++ b/lib/models/Sequelize.d.ts
@@ -1,5 +1,5 @@
 import 'reflect-metadata';
-import * as SequelizeOrigin from 'sequelize';
+import SequelizeOrigin = require('sequelize');
 import {Model} from "./Model";
 import {SequelizeConfig} from "../types/SequelizeConfig";
 import {ISequelizeValidationOnlyConfig} from "../interfaces/ISequelizeValidationOnlyConfig";

--- a/lib/models/v3/Sequelize.ts
+++ b/lib/models/v3/Sequelize.ts
@@ -1,5 +1,5 @@
 import 'reflect-metadata';
-import * as SequelizeOrigin from 'sequelize';
+import SequelizeOrigin = require('sequelize');
 import {Model} from "../Model";
 import {SequelizeConfig} from "../../types/SequelizeConfig";
 import {getModelName, getAttributes, getOptions} from "../../services/models";

--- a/lib/models/v4/Sequelize.ts
+++ b/lib/models/v4/Sequelize.ts
@@ -1,5 +1,5 @@
 import 'reflect-metadata';
-import * as OriginSequelize from 'sequelize';
+import OriginSequelize = require('sequelize');
 import {Model} from "../Model";
 import {SequelizeConfig} from "../../types/SequelizeConfig";
 import {getModelName, getAttributes, getOptions} from "../../services/models";


### PR DESCRIPTION
Fixes https://github.com/RobinBuschmann/sequelize-typescript/issues/330

I've also tried [bumping `typescript` and setting `esModuleInterop` to `true`](https://github.com/johannes-scharlach/sequelize-typescript/commit/9c5daa47f079c48ebe9d5eeaee87a0c65344e1e7). The proposed changes also worked with the newer version, but I'm not sure if that would introduce a breaking change to `sequelize-typescript`. The recommendation seems to be to set that flag to true when you can.

I've taken the solution from this issue https://github.com/Microsoft/TypeScript/issues/21535#issuecomment-362399044