### PR TITLE
chore(release): v2.1.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,18 +1,24 @@
 # Changelog
 
+## [2.1.1](https://github.com/RobinBuschmann/sequelize-typescript/compare/v2.1.0...v2.1.1) (2021-10-10)
+
+### Bug Fixes
+
+* **model:** adjust init method to recently introduced sequelize type changes ([b60c011](https://github.com/RobinBuschmann/sequelize-typescript/commit/b60c011be2e971e56cb783d4ade994965faab916))
+
 ## [2.1.0](https://github.com/RobinBuschmann/sequelize-typescript/compare/v2.0.0-beta.1...v2.1.0) (2021-02-14)
 
 Initial release with Changelog.
 
 ### Bug Fixes
 
-- allow $set null (remove association) ([#774](https://github.com/RobinBuschmann/sequelize-typescript/issues/774)) ([ffe1c78](https://github.com/RobinBuschmann/sequelize-typescript/commit/ffe1c78df73df7f287b8ce345d6ac0df30283723))
-- model associations methods to reflect sequelize v6 ([#888](https://github.com/RobinBuschmann/sequelize-typescript/issues/888)) ([6b1e3ff](https://github.com/RobinBuschmann/sequelize-typescript/commit/6b1e3fffd974f087be2e18258306f81860923ba3))
-- typeof Model errors by using typeof Model generics ([#900](https://github.com/RobinBuschmann/sequelize-typescript/issues/900)) ([b865840](https://github.com/RobinBuschmann/sequelize-typescript/commit/b8658404f12e7a44893c9b8652714473bb25f495))
+* allow $set null (remove association) ([#774](https://github.com/RobinBuschmann/sequelize-typescript/issues/774)) ([ffe1c78](https://github.com/RobinBuschmann/sequelize-typescript/commit/ffe1c78df73df7f287b8ce345d6ac0df30283723))
+* model associations methods to reflect sequelize v6 ([#888](https://github.com/RobinBuschmann/sequelize-typescript/issues/888)) ([6b1e3ff](https://github.com/RobinBuschmann/sequelize-typescript/commit/6b1e3fffd974f087be2e18258306f81860923ba3))
+* typeof Model errors by using typeof Model generics ([#900](https://github.com/RobinBuschmann/sequelize-typescript/issues/900)) ([b865840](https://github.com/RobinBuschmann/sequelize-typescript/commit/b8658404f12e7a44893c9b8652714473bb25f495))
 
 ### Features
 
-- infer bigint data type ([#893](https://github.com/RobinBuschmann/sequelize-typescript/issues/893)) ([7c467d4](https://github.com/RobinBuschmann/sequelize-typescript/commit/7c467d404a200b3153cc7aa2605d1e542bef3da9))
+* infer bigint data type ([#893](https://github.com/RobinBuschmann/sequelize-typescript/issues/893)) ([7c467d4](https://github.com/RobinBuschmann/sequelize-typescript/commit/7c467d404a200b3153cc7aa2605d1e542bef3da9))
 
 ## Older versions
 
@@ -45,17 +51,17 @@ npm install sequelize-typescript@0.6
 
 ### Upgrade to `sequelize-typescript@2`
 
-- `sequelize-typescript@2` only works with `sequelize@6.2>=`.
+* `sequelize-typescript@2` only works with `sequelize@6.2>=`.
   For `sequelize@5` use `sequelize-typescript@1.0`.
 
 #### Breaking Changes
 
-- All breaking changes of `sequelize@6` are also valid for `sequelize-typescript@2`.
+* All breaking changes of `sequelize@6` are also valid for `sequelize-typescript@2`.
   See [Upgrade to v6](https://sequelize.org/master/manual/upgrade-to-v6.html) for details.
-- `@types/bluebird` is no longer needed, `sequelize@6` removed usage of `bluebird`
-- Sequelize v6.2 introduced additional model attributes typings, which affects how the model is defined.
-- See below comparison between V5 and V6 model definition to show how to upgrade models.
-- For more details, see [sequelize typescript docs](https://sequelize.org/master/manual/typescript.html).
+* `@types/bluebird` is no longer needed, `sequelize@6` removed usage of `bluebird`
+* Sequelize v6.2 introduced additional model attributes typings, which affects how the model is defined.
+* See below comparison between V5 and V6 model definition to show how to upgrade models.
+* For more details, see [sequelize typescript docs](https://sequelize.org/master/manual/typescript.html).
 
 ### Upgrade to `sequelize-typescript@1`
 
@@ -73,7 +79,7 @@ sequelize-typescript now uses the official typings bundled with sequelize
 (See [this](https://sequelize.org/v5/manual/upgrade-to-v5.html#typescript-support)).
 Please note the following details:
 
-- Most of the sequelize-typescript interfaces of the previous version are replaced by the official ones
-- `@types/sequelize` is no longer used
-- `@types/bluebird` is no longer an explicit dependency
-- The official typings are less strict than the former sequelize-typescript ones
+* Most of the sequelize-typescript interfaces of the previous version are replaced by the official ones
+* `@types/sequelize` is no longer used
+* `@types/bluebird` is no longer an explicit dependency
+* The official typings are less strict than the former sequelize-typescript ones

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "sequelize-typescript",
-  "version": "2.1.0",
+  "version": "2.1.1",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "sequelize-typescript",
-      "version": "2.1.0",
+      "version": "2.1.1",
       "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "sequelize-typescript",
-  "version": "2.1.0",
+  "version": "2.1.1",
   "description": "Decorators and some other features for sequelize",
   "scripts": {
     "build": "tsc",


### PR DESCRIPTION
Release v2.1.1 to fix broken sequelize 6.6.5+ types