### PR TITLE
fix(validators): allow any values for isIn/notIn

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -48,7 +48,7 @@
         "prettyjson": "1.2.1",
         "reflect-metadata": "0.1.13",
         "release-it": "14.11.6",
-        "sequelize": "6.6.5",
+        "sequelize": "6.8.0",
         "sinon": "11.1.2",
         "sinon-chai": "3.7.0",
         "source-map-support": "0.5.20",
@@ -8426,9 +8426,9 @@
       "dev": true
     },
     "node_modules/sequelize": {
-      "version": "6.6.5",
-      "resolved": "https://registry.npmjs.org/sequelize/-/sequelize-6.6.5.tgz",
-      "integrity": "sha512-QyRrJrDRiwuiILqTMHUA1yWOPIL12KlfmgZ3hnzQwbMvp2vJ6fzu9bYJQB+qPMosck4mBUggY4Cjoc6Et8FBIQ==",
+      "version": "6.8.0",
+      "resolved": "https://registry.npmjs.org/sequelize/-/sequelize-6.8.0.tgz",
+      "integrity": "sha512-tekqSMoEuhlXfc9f/WduQr+9CS87bPWw/GKEvd+zMlOlMVFOzNx9PecQV+McjA7OUNUa1YGyPEt+Fe8baXST5A==",
       "dev": true,
       "dependencies": {
         "debug": "^4.1.1",
@@ -16360,9 +16360,9 @@
       "dev": true
     },
     "sequelize": {
-      "version": "6.6.5",
-      "resolved": "https://registry.npmjs.org/sequelize/-/sequelize-6.6.5.tgz",
-      "integrity": "sha512-QyRrJrDRiwuiILqTMHUA1yWOPIL12KlfmgZ3hnzQwbMvp2vJ6fzu9bYJQB+qPMosck4mBUggY4Cjoc6Et8FBIQ==",
+      "version": "6.8.0",
+      "resolved": "https://registry.npmjs.org/sequelize/-/sequelize-6.8.0.tgz",
+      "integrity": "sha512-tekqSMoEuhlXfc9f/WduQr+9CS87bPWw/GKEvd+zMlOlMVFOzNx9PecQV+McjA7OUNUa1YGyPEt+Fe8baXST5A==",
       "dev": true,
       "requires": {
         "debug": "^4.1.1",

--- a/package.json
+++ b/package.json
@@ -131,7 +131,7 @@
     "prettyjson": "1.2.1",
     "reflect-metadata": "0.1.13",
     "release-it": "14.11.6",
-    "sequelize": "6.6.5",
+    "sequelize": "6.8.0",
     "sinon": "11.1.2",
     "sinon-chai": "3.7.0",
     "source-map-support": "0.5.20",
@@ -144,6 +144,6 @@
     "@types/node": "*",
     "@types/validator": "*",
     "reflect-metadata": "*",
-    "sequelize": ">=6.6.5"
+    "sequelize": ">=6.8.0"
   }
 }

--- a/src/validation/is-in.ts
+++ b/src/validation/is-in.ts
@@ -3,7 +3,7 @@ import { addAttributeOptions } from '../model/column/attribute-service';
 /**
  * Check the value is one of these
  */
-export function IsIn(arg: string[][] | { msg: string; args: string[][] }): Function {
+export function IsIn(arg: any[][] | { msg: string; args: any[][] }): Function {
   return (target: any, propertyName: string) =>
     addAttributeOptions(target, propertyName, {
       validate: {

--- a/src/validation/not-in.ts
+++ b/src/validation/not-in.ts
@@ -3,7 +3,7 @@ import { addAttributeOptions } from '../model/column/attribute-service';
 /**
  * Check the value is not one of these
  */
-export function NotIn(arg: string[][] | { msg: string; args: string[][] }): Function {
+export function NotIn(arg: any[][] | { msg: string; args: any[][] }): Function {
   return (target: any, propertyName: string) =>
     addAttributeOptions(target, propertyName, {
       validate: {


### PR DESCRIPTION
This is a follow up of https://github.com/sequelize/sequelize/pull/12962, which has now been fixed in sequelize 6.8.0. Since types are now fixed in sequelize, decorator types can now be correctly aligned with the implementation. Fixes #866.