### PR TITLE
Add support to underscored tables

### DIFF
--- a/src/model/index/index-service.ts
+++ b/src/model/index/index-service.ts
@@ -16,10 +16,7 @@ export interface IndexesMeta {
   unnamed: IndexOptions[];
 }
 
-export type IndexOptions = Pick<
-  SequelizeIndexOptions,
-  Exclude<keyof SequelizeIndexOptions, 'fields'>
->;
+export type IndexOptions = SequelizeIndexOptions;
 
 /**
  * Returns model indexes from class by restoring this

--- a/src/sequelize/sequelize/sequelize.ts
+++ b/src/sequelize/sequelize/sequelize.ts
@@ -10,6 +10,7 @@ import { getAssociations } from '../../associations/shared/association-service';
 import { getAttributes } from '../../model/column/attribute-service';
 import { getIndexes } from '../../model/index/index-service';
 import { Repository } from '../..';
+import { snakeCase } from 'lodash';
 
 export class Sequelize extends OriginSequelize {
   options: SequelizeOptions;
@@ -93,6 +94,20 @@ export class Sequelize extends OriginSequelize {
       const indexArray = Object.keys(indexes.named)
         .map((key) => indexes.named[key])
         .concat(indexes.unnamed);
+
+      if (modelOptions.underscored) {
+        indexArray.forEach((index) => {
+          index.fields?.forEach((field) => {
+            const value = field.valueOf();
+            if (typeof value === 'object') {
+              field['name'] = snakeCase(value['name']);
+            } else if (typeof value === 'string') {
+              field = snakeCase(value);
+            }
+          });
+        });
+      }
+
       const initOptions: InitOptions & { modelName } = {
         ...(indexArray.length > 0 && { indexes: indexArray }),
         ...modelOptions,

--- a/test/specs/index.spec.ts
+++ b/test/specs/index.spec.ts
@@ -241,4 +241,22 @@ describe('custom index decorator', () => {
       'CREATE INDEX `my-index` ON `Tests`' + ' (`fieldA` COLLATE `NOCASE` ASC, `fieldB` DESC)'
     );
   });
+
+  it('creates index using underscored', async () => {
+    @Table({ underscored: true })
+    class Test extends Model {
+      @Index
+      @Column
+      fieldName: string;
+    }
+    sequelize.addModels([Test]);
+
+    const queries = [];
+    await Test.sync({
+      force: true,
+      logging: (sql) => queries.push(sql.substr(sql.indexOf(':') + 2)),
+    });
+    expect(queries).to.have.property('length', 4);
+    expect(queries[3]).to.equal('CREATE INDEX `tests_field_name` ON `tests` (`field_name`)');
+  });
 });


### PR DESCRIPTION
Hi guys, I was developing a small project and I found a bug.

Basically when we create an index with a table with the underscored property, we get an SQL error. As it seemed like a simple bug, I decided to explore to try to find a solution.

The idea I had is very simple, if you have the property, let's convert the name of all the fields of all the indexes to snake case and that's what I did, apparently it solves the problem.

This is my first contribution to an open source project, please be patient :)

Other people reported this bug in this issue #725 
