### PR TITLE
feat: remove @types/node in peerDependencies

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,7 +43,7 @@ Decorators and some other features for sequelize (v6).
 - additional typings as documented [here](https://sequelize.org/master/manual/typescript.html) and [reflect-metadata](https://www.npmjs.com/package/reflect-metadata)
 
 ```sh
-npm install --save-dev @types/node @types/validator
+npm install --save-dev @types/validator
 npm install sequelize reflect-metadata sequelize-typescript
 ```
 

--- a/package.json
+++ b/package.json
@@ -141,7 +141,6 @@
     "uuid-validate": "0.0.3"
   },
   "peerDependencies": {
-    "@types/node": "*",
     "@types/validator": "*",
     "reflect-metadata": "*",
     "sequelize": ">=6.20.1"


### PR DESCRIPTION
I have a monorepo project. The root of the project have specified node version by installing `@types/node` to devDependencies. Therefore, it no need to install `@types/node` to sub-app.