### PR TITLE
fix: globbing under Windows `models` option

### DIFF
--- a/src/sequelize/sequelize/sequelize-service.ts
+++ b/src/sequelize/sequelize/sequelize-service.ts
@@ -41,6 +41,7 @@ export function getModels(arg: (ModelCtor | string)[], modelMatch: ModelMatch): 
   if (arg && typeof arg[0] === 'string') {
     return arg.reduce((models: any[], dir) => {
       if (!glob.hasMagic(dir) && !hasSupportedExtension(dir)) dir = join(dir as string, '/*');
+      dir = dir.replaceAll('\\', '/');
       const _models = glob
         .sync(dir as string)
         .filter(isImportable)


### PR DESCRIPTION
The version 8 of the node-glob module only supports slashes.