### PR TITLE
ci: sequelize renovate setup

### DIFF
--- a/.commitlintrc.json
+++ b/.commitlintrc.json
@@ -1,6 +1,24 @@
 {
   "extends": ["@commitlint/config-conventional"],
   "rules": {
-    "body-max-line-length": [0]
+    "body-max-line-length": [0],
+    "type-enum": [
+      2,
+      "always",
+      [
+        "build",
+        "chore",
+        "ci",
+        "docs",
+        "feat",
+        "fix",
+        "perf",
+        "refactor",
+        "revert",
+        "style",
+        "test",
+        "meta"
+      ]
+    ]
   }
 }

--- a/renovate.json
+++ b/renovate.json
@@ -1,0 +1,21 @@
+{
+  "extends": [
+    "config:base",
+    ":maintainLockFilesWeekly",
+    ":semanticCommitTypeAll(meta)",
+    ":semanticCommitScopeDisabled"
+  ],
+  "automergeStrategy": "squash",
+  "semanticCommitType": "meta",
+  "packageRules": [
+    {
+      "matchUpdateTypes": ["minor", "patch", "pin", "digest"],
+      "automerge": true
+    },
+    {
+      "matchPackageNames": ["mocha", "@types/mocha", "sinon", "@types/sinon"],
+      "matchUpdateTypes": ["major"],
+      "enabled": false
+    }
+  ]
+}


### PR DESCRIPTION
Sequelize-inspired renovate setup to sync the deps maintenance strategy. Additionally ignores couple of deps that drop earlier node.js support which sequelize V6 still retains. I think someone with enough rights will have to enable the renovate app for this repo if it is deemed to be merged.

@WikiRik, @sdepold, @ephys, what do you think? I'm hoping this should be easier to maintain same deps strategy as sequelize V6 and sequelize-ts@v2 will still linger around for a bit.