### PR TITLE
Comments on type ScopesOptionsGetter

### DIFF
--- a/src/scopes/scope-options.ts
+++ b/src/scopes/scope-options.ts
@@ -13,5 +13,18 @@ export interface ScopeOptionsGetters {
 }
 
 export type DefaultScopeGetter = () => FindOptions;
+
+/**
+ * This is the type that you should use if adding a new set of scopes
+ * @example
+ * const myModelScopes: ScopesOptionsGetter = ()  => ({
+ *  scopeOne: FindOptions & IncludeOptions {
+ *    return {...}
+ *  },
+ *  scopeTwo: FindOptions {
+ *    return {...}
+ *  }
+ * })
+ */
 export type ScopesOptionsGetter = () => { [sopeName: string]: ScopesOptions };
 export type ScopesOptions = FindOptions | ((...args: any[]) => FindOptions);


### PR DESCRIPTION
this just explains the use of ScopesOptionsGetter.
this might help to solve issues like [ Can't define scopes in separate variables/files to use in the @DefaultScope and @Scope decorators #891 ](https://github.com/sequelize/sequelize-typescript/issues/891) faster.